### PR TITLE
Add `CrawlEvent` with `case willCrawl`

### DIFF
--- a/Examples/ImageScraperExample/ImageScraperExample.swift
+++ b/Examples/ImageScraperExample/ImageScraperExample.swift
@@ -72,11 +72,13 @@ struct ImageScraperExample
 
         await withThrowingTaskGroup(of: Void.self, returning: Void.self) { group in
             group.addTask {
-                for await (req, result) in imageDownloader.outputs {
-                    switch result {
-                    case let .success(output):
+                for await event in imageDownloader.events {
+                    switch event {
+                    case let .willCrawl(req):
+                        print("🖼️ Image Crawl : 🕸️ [\(req.order)] [d=\(req.depth)] \(req.url)")
+                    case let .didCrawl(req, .success(output)):
                         print("🖼️ Image Output: ✅ [\(req.order)] [d=\(req.depth)] \(req.url), savedFileURL = \(output.savedFileURL)")
-                    case let .failure(error):
+                    case let .didCrawl(req, .failure(error)):
                         print("🖼️ Image Output: ❌ [\(req.order)] [d=\(req.depth)] \(req.url), error = \(error)")
                     }
                 }
@@ -84,11 +86,13 @@ struct ImageScraperExample
                 print("Image Output Done")
             }
             group.addTask {
-                for await (req, result) in htmlCrawler.outputs {
-                    switch result {
-                    case .success:
+                for await event in htmlCrawler.events {
+                    switch event {
+                    case let .willCrawl(req):
+                        print("🌐 HTML Crawl : 🕸️ [\(req.order)] [d=\(req.depth)] \(req.url)")
+                    case let .didCrawl(req, .success):
                         print("🌐 HTML Output: ✅ [\(req.order)] [d=\(req.depth)] \(req.url)")
-                    case let .failure(error):
+                    case let .didCrawl(req, .failure(error)):
                         print("🌐 HTML Output: ❌ [\(req.order)] [d=\(req.depth)] \(req.url), error = \(error)")
                     }
                 }

--- a/Examples/PagingScraperExample/PagingScraperExample.swift
+++ b/Examples/PagingScraperExample/PagingScraperExample.swift
@@ -56,11 +56,13 @@ struct PagingScraperExample
 
         htmlCrawler.visit(url: URL(string: "https://news.ycombinator.com/news")!, urlInfo: .page(1))
 
-        for await (req, result) in htmlCrawler.outputs {
-            switch result {
-            case let .success(output):
+        for await event in htmlCrawler.events {
+            switch event {
+            case let .willCrawl(req):
+                print("Crawl : 🕸️ [\(req.order)] [d=\(req.depth)] \(req.url)")
+            case let .didCrawl(req, .success(output)):
                 print("Output: ✅ [\(req.order)] [d=\(req.depth)] \(req.url), message = \(output.message)")
-            case let .failure(error):
+            case let .didCrawl(req, .failure(error)):
                 print("Output: ❌ [\(req.order)] [d=\(req.depth)] \(req.url), error = \(error)")
             }
         }

--- a/Examples/ScraperExample/ScraperExample.swift
+++ b/Examples/ScraperExample/ScraperExample.swift
@@ -31,11 +31,13 @@ struct ScraperExample
 
         htmlCrawler.visit(url: URL(string: "https://www.wikipedia.org")!)
 
-        for await (req, result) in htmlCrawler.outputs {
-            switch result {
-            case .success:
-                print("Output: ✅ [\(req.order)] [d=\(req.depth)] \(req.url)")
-            case let .failure(error):
+        for await event in htmlCrawler.events {
+            switch event {
+            case let .willCrawl(req):
+                print("Crawl : 🕸️ [\(req.order)] [d=\(req.depth)] \(req.url)")
+            case let .didCrawl(req, .success(output)):
+                print("Output: ✅ [\(req.order)] [d=\(req.depth)] \(req.url), nextLinksCount = \(output.nextLinksCount)")
+            case let .didCrawl(req, .failure(error)):
                 print("Output: ❌ [\(req.order)] [d=\(req.depth)] \(req.url), error = \(error)")
             }
         }

--- a/README.md
+++ b/README.md
@@ -7,56 +7,51 @@
 - [Examples](Examples)
 
 ```swift
-@main
-struct ReadMeExample
+struct Output: Sendable
 {
-    static func main() async
-    {
-        struct Output: Sendable
-        {
-            let nextLinksCount: Int
-        }
+    let nextLinksCount: Int
+}
 
-        let htmlCrawler = Crawler<Output, Void>.htmlScraper(
-            config: CrawlerConfig(
-                maxDepths: 10,
-                maxTotalRequests: 100,
-                timeoutPerRequest: 5,
-                userAgent: "ActoCrawler",
-                domainFilteringPolicy: .disallowedDomains([".*google.com*" /* ... */]),
-                domainQueueTable: [
-                    ".*example1.com*": .init(maxConcurrency: 1, delay: 0),
-                    ".*example2.com*": .init(maxConcurrency: 5, delay: 0.1 ... 0.5)
-                ]
-            ),
-            scrapeHTML: { response in
-                let html = response.data
-                let links = try html.select("a").map { try $0.attr("href") }
+let htmlCrawler = await Crawler<Output, Void>.htmlScraper(
+    config: CrawlerConfig(
+        maxDepths: 10,
+        maxTotalRequests: 100,
+        timeoutPerRequest: 5,
+        userAgent: "ActoCrawler",
+        domainFilteringPolicy: .disallowedDomains([".*google.com*" /* ... */]),
+        domainQueueTable: [
+            ".*example1.com*": .init(maxConcurrency: 1, delay: 0),
+            ".*example2.com*": .init(maxConcurrency: 5, delay: 0.1 ... 0.5)
+        ]
+    ),
+    scrapeHTML: { response in
+        let html = response.data
+        let links = try html.select("a").map { try $0.attr("href") }
 
-                let nextRequests = links
-                    .compactMap(URL.init(string:))
-                    .map { UserRequest(url: $0) }
+        let nextRequests = links
+            .compactMap(URL.init(string:))
+            .map { UserRequest(url: $0) }
 
-                return (nextRequests, Output(nextLinksCount: nextRequests.count))
-            }
-        )
+        return (nextRequests, Output(nextLinksCount: nextRequests.count))
+    }
+)
 
-        // Visit initial page.
-        htmlCrawler.visit(url: URL(string: "https://www.wikipedia.org")!)
+// Visit initial page.
+htmlCrawler.visit(url: URL(string: "https://www.wikipedia.org")!)
 
-        // Observe visited outputs.
-        for await (req, result) in htmlCrawler.outputs {
-            switch result {
-            case let .success(output):
-                print("Output: ✅ [\(req.order)] [d=\(req.depth)] \(req.url), nextLinksCount = \(output.nextLinksCount)")
-            case let .failure(error):
-                print("Output: ❌ [\(req.order)] [d=\(req.depth)] \(req.url), error = \(error)")
-            }
-        }
-
-        print("Output Done")
+// Observe crawl events.
+for await event in htmlCrawler.events {
+    switch event {
+    case let .willCrawl(req):
+        print("Crawl : 🕸️ [\(req.order)] [d=\(req.depth)] \(req.url)")
+    case let .didCrawl(req, .success(output)):
+        print("Output: ✅ [\(req.order)] [d=\(req.depth)] \(req.url), nextLinksCount = \(output.nextLinksCount)")
+    case let .didCrawl(req, .failure(error)):
+        print("Output: ❌ [\(req.order)] [d=\(req.depth)] \(req.url), error = \(error)")
     }
 }
+
+print("Output Done")
 ```
 
 ## Acknowledgements

--- a/Sources/ActoCrawler/CrawlEvent.swift
+++ b/Sources/ActoCrawler/CrawlEvent.swift
@@ -1,0 +1,7 @@
+/// Crawler output event to be delivered to ``Crawler/events``.
+public enum CrawlEvent<Output, URLInfo>: Sendable
+    where Output: Sendable, URLInfo: Sendable
+{
+    case willCrawl(Request<URLInfo>)
+    case didCrawl(Request<URLInfo>, Result<Output, CrawlError>)
+}

--- a/Sources/ActoCrawler/Crawler.htmlScraper.swift.swift
+++ b/Sources/ActoCrawler/Crawler.htmlScraper.swift.swift
@@ -9,10 +9,10 @@ extension Crawler
     ///   - scrapeHTML:
     ///     Receives `Response` that contains HTML `Document` to be scraped,
     ///     and returns array of next `UserRequest`s as well as `Output` for current request output.
-    ///     If `Error` is thrown inside this closure, it will be observed as a failure of ``Crawler/outputs``.
+    ///     If `Error` is thrown inside this closure, it will be observed as a failure of ``Crawler/events``.
     public static func htmlScraper(
         config: CrawlerConfig,
-        scrapeHTML: @escaping @Sendable (Response<Document, URLInfo>) async throws -> ([UserRequest<URLInfo>], Output?)
+        scrapeHTML: @escaping @Sendable (Response<Document, URLInfo>) async throws -> ([UserRequest<URLInfo>], Output)
     ) async -> Crawler
         where Output: Sendable
     {

--- a/Sources/ActoCrawler/Crawler.swift
+++ b/Sources/ActoCrawler/Crawler.swift
@@ -21,11 +21,11 @@ public struct Crawler<Output, URLInfo>: Sendable
     ///   - crawl:
     ///     Receives `Request` to perform some async operations (e.g. network requesting and parsing),
     ///     and returns array of next `UserRequest`s as well as `Output` for current request output.
-    ///     If `Error` is thrown inside this closure, it will be observed as a failure of ``Crawler/outputs``.
+    ///     If `Error` is thrown inside this closure, it will be observed as a failure of ``Crawler/events``.
     public init<Dependency>(
         config: CrawlerConfig,
         dependency: Dependency,
-        crawl: @escaping @Sendable (Request<URLInfo>, Dependency) async throws -> ([UserRequest<URLInfo>], Output?)
+        crawl: @escaping @Sendable (Request<URLInfo>, Dependency) async throws -> ([UserRequest<URLInfo>], Output)
     )
         where Dependency: Sendable
     {
@@ -42,7 +42,7 @@ public struct Crawler<Output, URLInfo>: Sendable
     /// Helper initializer that adds ``NetworkSession`` as dependency.
     public static func withNetworkSession(
         config: CrawlerConfig,
-        crawl: @escaping @Sendable (Request<URLInfo>, NetworkSession) async throws -> ([UserRequest<URLInfo>], Output?)
+        crawl: @escaping @Sendable (Request<URLInfo>, NetworkSession) async throws -> ([UserRequest<URLInfo>], Output)
     ) async -> Crawler<Output, URLInfo>
     {
         let configuration: URLSessionConfiguration = {
@@ -54,11 +54,11 @@ public struct Crawler<Output, URLInfo>: Sendable
         return .init(config: config, dependency: await NetworkSession(configuration: configuration), crawl: crawl)
     }
 
-    /// Output `AsyncSequence`  as a result of `crawl`.
+    /// Crawler output event `AsyncSequence`.
     /// - Todo: `any `AsyncSequence`.`
-    public var outputs: AsyncChannel<(Request<URLInfo>, Result<Output, CrawlError>)>
+    public var events: AsyncChannel<CrawlEvent<Output, URLInfo>>
     {
-        self.environment.outputs
+        self.environment.events
     }
 
     /// Visits `url` as depth = 1 without `urlInfo`.

--- a/Sources/ActoCrawler/Internal/Environment.swift
+++ b/Sources/ActoCrawler/Internal/Environment.swift
@@ -9,16 +9,16 @@ struct Environment<Output, URLInfo>: Sendable
 
     /// Receives `Request` to perform some async operations (e.g. network requesting and parsing),
     /// and returns array of next `Request`s as well as `Output`.
-    let crawl: @Sendable (Request<URLInfo>) async throws -> ([UserRequest<URLInfo>], Output?)
+    let crawl: @Sendable (Request<URLInfo>) async throws -> ([UserRequest<URLInfo>], Output)
 
-    /// Output `AsyncSequence`  as a result of `crawl`.
+    /// Crawler output event `AsyncSequence`.
     /// - Todo: `any `AsyncSequence`.
-    let outputs: AsyncChannel<(Request<URLInfo>, Result<Output, CrawlError>)> = .init()
+    let events: AsyncChannel<CrawlEvent<Output, URLInfo>> = .init()
 
     init<Dependency>(
         config: CrawlerConfig,
         dependency: Dependency,
-        crawl: @escaping @Sendable (Request<URLInfo>, Dependency) async throws -> ([UserRequest<URLInfo>], Output?)
+        crawl: @escaping @Sendable (Request<URLInfo>, Dependency) async throws -> ([UserRequest<URLInfo>], Output)
     )
         where Dependency: Sendable
     {

--- a/Tests/ActoCrawlerTests/ReadMeExample.swift
+++ b/Tests/ActoCrawlerTests/ReadMeExample.swift
@@ -39,12 +39,14 @@ struct ReadMeExample
         // Visit initial page.
         htmlCrawler.visit(url: URL(string: "https://www.wikipedia.org")!)
 
-        // Observe visited outputs.
-        for await (req, result) in htmlCrawler.outputs {
-            switch result {
-            case let .success(output):
+        // Observe crawl events.
+        for await event in htmlCrawler.events {
+            switch event {
+            case let .willCrawl(req):
+                print("Crawl : 🕸️ [\(req.order)] [d=\(req.depth)] \(req.url)")
+            case let .didCrawl(req, .success(output)):
                 print("Output: ✅ [\(req.order)] [d=\(req.depth)] \(req.url), nextLinksCount = \(output.nextLinksCount)")
-            case let .failure(error):
+            case let .didCrawl(req, .failure(error)):
                 print("Output: ❌ [\(req.order)] [d=\(req.depth)] \(req.url), error = \(error)")
             }
         }


### PR DESCRIPTION
This PR adds `CrawlEvent` with `case willCrawl` so that beginning of the crawling events can also be observed.

There are some renamings from "output" to "event", and usage of `Output?` is now simplified into `Output` (non-optional).