### PR TITLE
Add ActoCrawlerPlaywright & HeadlessBrowserExample

### DIFF
--- a/Examples/HeadlessBrowserExample/HeadlessBrowserExample.swift
+++ b/Examples/HeadlessBrowserExample/HeadlessBrowserExample.swift
@@ -1,0 +1,88 @@
+import Foundation
+import ActoCrawler
+import ActoCrawlerPlaywright
+
+/// [playwright-python](https://playwright.dev/python/docs/intro) (headless browser) example.
+@main
+struct HeadlessBrowserExample
+{
+    static func main() async
+    {
+        struct Output: Sendable
+        {
+            let screenshotPath: String
+        }
+
+        let home = NSHomeDirectory()
+
+        let crawler = await Crawler<Output, Void>.withPlaywright(
+            pythonPackagePaths: [
+                // NOTE: Change path to your own settings.
+                "\(home)/.pyenv/versions/miniforge3-4.10.3-10/envs/ml/lib/python3.9/site-packages"
+            ],
+            config: CrawlerConfig(
+                maxTotalRequests: 8,
+                domainQueueTable: [
+                    ".*": .init(maxConcurrency: 5, delay: 0)
+                ]
+            ),
+            crawl: { request, playwright, browser in
+                // NOTE:
+                // `playwright` is `PythonObject` that can inter-op with Python using `@dynamicMemberLookup`.
+                // For playwright-python APIs, see documentation:
+                // https://playwright.dev/python/docs/intro
+
+                let context = await browser.new_context().asPyAsync()
+                let page = await context.new_page().asPyAsync()
+
+                // Visit URL.
+                await page.goto(request.url.absoluteString).asPyAsync()
+
+                // Take screenshot.
+                let screenshotPath = "screenshots/example-\(request.order).png"
+                await page.screenshot(path: screenshotPath).asPyAsync()
+
+                // Extract next URL links.
+                // https://playwright.dev/python/docs/evaluating
+                let linkObjects = await page
+                    .evaluate("() => Array.from(document.links).map(item => item.href)")
+                    .asPyAsync()
+
+                let nextUserRequests: [UserRequest<Void>]
+                if let links: [String] = Array(linkObjects) {
+                    nextUserRequests = links
+                        .compactMap { URL(string: $0).map(UserRequest.init(url:)) }
+                        .shuffled()
+                }
+                else {
+                    nextUserRequests = []
+                }
+
+                await page.close().asPyAsync()
+                await context.close().asPyAsync()
+
+                return (nextUserRequests, Output(screenshotPath: screenshotPath))
+            }
+        )
+
+        // Initial crawls.
+        crawler.visit(requests: [
+            .init(url: URL(string: "https://en.wikipedia.org")!),
+            .init(url: URL(string: "https://ja.wikipedia.org")!),
+            .init(url: URL(string: "https://zh.wikipedia.org")!),
+        ])
+
+        for await event in crawler.events {
+            switch event {
+            case let .willCrawl(req):
+                print("Crawl : 🕸️ [\(req.order)] [d=\(req.depth)] \(req.url)")
+            case let .didCrawl(req, .success(output)):
+                print("Output: ✅ [\(req.order)] [d=\(req.depth)] \(req.url), screenshotPath = \(output.screenshotPath)")
+            case let .didCrawl(req, .failure(error)):
+                print("Output: ❌ [\(req.order)] [d=\(req.depth)] \(req.url), error = \(error)")
+            }
+        }
+
+        print("Output Done")
+    }
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "pythonkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pvieito/PythonKit.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "81f621d094a7c8923207efe5178f50dba1b56c39"
+      }
+    },
+    {
       "identity" : "swift-case-paths",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
         .library(
             name: "ActoCrawler",
             targets: ["ActoCrawler"]),
+        .library(
+            name: "ActoCrawlerPlaywright",
+            targets: ["ActoCrawlerPlaywright"]),
         .executable(
             name: "ScraperExample",
             targets: ["ScraperExample"]),
@@ -19,16 +22,27 @@ let package = Package(
         .executable(
             name: "PagingScraperExample",
             targets: ["PagingScraperExample"]),
+        .executable(
+            name: "HeadlessBrowserExample",
+            targets: ["HeadlessBrowserExample"]),
     ],
     dependencies: [
         .package(url: "https://github.com/inamiy/Actomaton.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         // .package(url: "https://github.com/apple/swift-async-algorithms.git", branch: "main"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.4.2"),
+        .package(url: "https://github.com/pvieito/PythonKit.git", branch: "master"),
     ],
     targets: [
         .target(
             name: "AsyncChannel"),
+        .target(
+            name: "PythonKitAsync",
+            dependencies: [
+                .product(name: "PythonKit", package: "PythonKit")
+            ],
+            resources: [.copy("pythonkit-async.py")]
+        ),
         .target(
             name: "ActoCrawler",
             dependencies: [
@@ -37,6 +51,18 @@ let package = Package(
                 .product(name: "Collections", package: "swift-collections"),
                 // .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
                 .product(name: "SwiftSoup", package: "SwiftSoup"),
+            ],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-Xfrontend", "-warn-concurrency",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                ])
+            ]
+        ),
+        .target(
+            name: "ActoCrawlerPlaywright",
+            dependencies: [
+                "ActoCrawler", "PythonKitAsync"
             ],
             swiftSettings: [
                 .unsafeFlags([
@@ -60,5 +86,9 @@ let package = Package(
             name: "PagingScraperExample",
             dependencies: ["ActoCrawler"],
             path: "Examples/PagingScraperExample"),
+        .executableTarget(
+            name: "HeadlessBrowserExample",
+            dependencies: ["ActoCrawlerPlaywright"],
+            path: "Examples/HeadlessBrowserExample"),
     ]
 )

--- a/Sources/ActoCrawlerPlaywright/Crawler.withPlaywright.swift
+++ b/Sources/ActoCrawlerPlaywright/Crawler.withPlaywright.swift
@@ -1,0 +1,66 @@
+import Foundation
+import ActoCrawler
+
+extension Crawler
+{
+    /// Helper initializer that adds [playwright-python](https://playwright.dev/python/docs/intro) (headless browser) as ActoCrawler's dependency.
+    ///
+    /// As written in the documentation, make sure to setup Python environment before calling this method:
+    ///
+    /// 1. `pip install playwright`
+    /// 2. `playwright install`
+    ///
+    /// - Parameters:
+    ///   - pythonPackagePaths:
+    ///     Python library paths for interacting with `playwright-python`. Use `pip show playwright` to find its locaiton.
+    ///
+    ///   - browser:
+    ///     Creates a new `Browser` object from `playwright` to reuse during crawling iterations.
+    ///     If `nil`, Chromium with non-headless mode will launch.
+    ///
+    ///     Example of this closure is:
+    ///     ```
+    ///     let browser = { await $0.chromium.launch(headless: false).asPyAsync() }
+    ///     ```
+    ///
+    ///   - crawl:
+    ///     Crawling function that receives
+    ///     [Playwright](https://github.com/microsoft/playwright-python/blob/v1.22.0/playwright/async_api/_generated.py#L12153)
+    ///     and [Browser](https://github.com/microsoft/playwright-python/blob/v1.22.0/playwright/async_api/_generated.py#L11134)
+    ///     as `PythonObject`s to inter-op with Python.
+    public static func withPlaywright(
+        pythonPackagePaths: [String],
+        config: CrawlerConfig,
+        browser: (@Sendable (_ playwright: PythonObject) async -> PythonObject)? = nil,
+        crawl: @escaping @CrawlActor @Sendable (
+            Request<URLInfo>,
+            _ playwright: PythonObject,
+            _ browser: PythonObject
+        ) async throws -> ([UserRequest<URLInfo>], Output)
+    ) async -> Crawler<Output, URLInfo>
+    {
+        let playwrightActor = await PlaywrightActor(
+            pythonPackagePaths: pythonPackagePaths,
+            prepare: browser ?? { await $0.chromium.launch(headless: false).asPyAsync() }
+        )
+
+        return Crawler<Output, URLInfo>(
+            config: config,
+            dependency: playwrightActor,
+            crawl: { request, playwrightActor in
+                try await playwrightActor.runCrawl {
+                    try await crawl(request, $0, $1)
+                }
+            }
+        )
+    }
+}
+
+// MARK: - Private
+
+/// Global actor for cooperative Playwright crawling to avoid `EXC_BAD_ACCESS`.
+@globalActor
+internal actor CrawlActor
+{
+    static let shared: CrawlActor = CrawlActor()
+}

--- a/Sources/ActoCrawlerPlaywright/PlaywrightActor.swift
+++ b/Sources/ActoCrawlerPlaywright/PlaywrightActor.swift
@@ -1,0 +1,60 @@
+import Foundation
+import ActoCrawler
+
+/// [playwright-python](https://playwright.dev/python/docs/intro) (headless browser) Actor wrapper.
+/// - Note: This will be used as a dependency of ActoCrawler, and stored throughout its lifetime.
+internal actor PlaywrightActor
+{
+    /// Root of `playwright/async_api`.
+    /// - [async_playwright](https://github.com/microsoft/playwright-python/blob/v1.22.0/playwright/async_api/__init__.py#L85)
+    /// - [PlaywrightContextManager](https://github.com/microsoft/playwright-python/blob/v1.22.0/playwright/async_api/_context_manager.py#L25)
+    private let playwrightContextManager: PythonObject
+
+    /// Python [Playwright](https://github.com/microsoft/playwright-python/blob/v1.22.0/playwright/async_api/_generated.py#L12153) object.
+    internal let playwright: PythonObject
+
+    /// Python object that is prepared via `init`'s `prepare`.
+    /// For example, preparing [Browser](https://github.com/microsoft/playwright-python/blob/v1.22.0/playwright/async_api/_generated.py#L11134)
+    /// is often useful not to launch multiple times and keep using the same reference.
+    internal let preparedObject: PythonObject
+
+    /// - Parameters:
+    ///   - pythonPackagePaths:
+    ///     Python library paths for interacting with `playwright-python`. Use `pip show playwright` to find its locaiton.
+    ///   - prepare:
+    ///     Async closure for setting-up `preparedObject`, which is usually a reusable `Browser`.
+    internal init(
+        pythonPackagePaths: [String],
+        prepare: @Sendable (_ playwright: PythonObject) async -> PythonObject
+    ) async
+    {
+        // Set PATH.
+        let sys = Python.import("sys")
+        for path in pythonPackagePaths {
+            sys.path.append(path)
+        }
+        sys.path.append(PythonKitAsync.bundleResourcePath) // For importing `pythonkit-async.py`.
+
+        let playwrightModule = Python.import("playwright.async_api")
+        self.playwrightContextManager = playwrightModule.async_playwright()
+        self.playwright = await self.playwrightContextManager.start().asPyAsync()
+        self.preparedObject = await prepare(self.playwright)
+    }
+
+    deinit
+    {
+        Task.detached {  [playwrightContextManager] in
+            await playwrightContextManager.__aexit__().asPyAsync()
+        }
+    }
+
+    internal func runCrawl<Res>(
+        _ crawl: @Sendable (
+            _ playwright: PythonObject,
+            _ setupObject: PythonObject
+        ) async throws -> Res
+    ) async rethrows -> Res
+    {
+        try await crawl(self.playwright, self.preparedObject)
+    }
+}

--- a/Sources/ActoCrawlerPlaywright/_exported.swift
+++ b/Sources/ActoCrawlerPlaywright/_exported.swift
@@ -1,0 +1,2 @@
+@_exported import PythonKit
+@_exported import PythonKitAsync

--- a/Sources/PythonKitAsync/Bundle.swift
+++ b/Sources/PythonKitAsync/Bundle.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Path to `pythonkit-async.py`
+public let bundleResourcePath: String = {
+    BundleToken.bundle.resourcePath!
+}()
+
+// MARK: - Private
+
+private final class BundleToken
+{
+    static let bundle: Bundle = {
+#if SWIFT_PACKAGE
+        return Bundle.module
+#else
+        return Bundle(for: BundleToken.self)
+#endif
+    }()
+}

--- a/Sources/PythonKitAsync/asPyAsync.swift
+++ b/Sources/PythonKitAsync/asPyAsync.swift
@@ -1,0 +1,26 @@
+import PythonKit
+
+// NOTE: 
+private let pythonKitAsync = Python.import("pythonkit-async")
+
+extension PythonObject
+{
+    /// Converts `self` as Python's coroutine (`async def`) object into Swift async function.
+    /// - Important: `self` must be Python coroutine object to run properly. Otherwise, async-returned value will be `self`.
+    @discardableResult
+    public func asPyAsync() async -> PythonObject
+    {
+        let pyObj: PythonObject = await withCheckedContinuation { continuation in
+            // NOTE: Uses `pythonkit-async.py`'s `coroutine_to_callback`.
+            pythonKitAsync.coroutine_to_callback(self, PythonFunction { (arg: PythonObject) in
+                continuation.resume(returning: arg)
+                return 0
+            })
+        }
+
+        // NOTE: Required to run other concurrent coroutines.
+        await Task.yield()
+
+        return pyObj
+    }
+}

--- a/Sources/PythonKitAsync/pythonkit-async.py
+++ b/Sources/PythonKitAsync/pythonkit-async.py
@@ -1,0 +1,12 @@
+import asyncio
+
+async def coroutine_wrapper(coroutine, callback):
+    val = await coroutine
+    callback(val)
+
+def coroutine_to_callback(coroutine, callback):
+    if asyncio.iscoroutine(coroutine):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(coroutine_wrapper(coroutine, callback))
+    else:
+        callback(coroutine) # Calls back immediately with non-coroutine object.


### PR DESCRIPTION
This PR adds `ActoCrawlerPlaywright` and `HeadlessBrowserExample` using `Playwright` (python version of web automation) and `PythonKit` (Swift-Python interop) libraries:

- [microsoft/playwright-python: Python version of the Playwright testing and automation library.](https://github.com/microsoft/playwright-python)
- [pvieito/PythonKit: Swift framework to interact with Python.](https://github.com/pvieito/PythonKit)

The basic usage of Playwright can be easily followed by [Getting started | Playwright Python](https://playwright.dev/python/docs/intro).

To bring Python async-await into Swift Concurrency world, this PR also adds `PythonKitAsync` module as a quick wrapper.
(CAVEAT: This approach may not be ideal due to slower browsing, possibly by multiple Python coroutines not being able to switch to the next one in their concurrency world)

## Screencast

```sh
$ swift run HeadlessBrowserExample
```

https://user-images.githubusercontent.com/138476/170487944-b2bc5e2e-8021-4c36-ba2f-5f2c77421ebe.mp4



