### PR TITLE
Add ActoCrawlerPlaywrightJS & HeadlessBrowserJSExample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ iOSInjectionProject/
 
 # HeadlessBrowserExample output
 Examples/HeadlessBrowserExample/output/
+Examples/HeadlessBrowserJSExample/output/

--- a/Examples/HeadlessBrowserJSExample/.gitignore
+++ b/Examples/HeadlessBrowserJSExample/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Examples/HeadlessBrowserJSExample/HeadlessBrowserJSExample.swift
+++ b/Examples/HeadlessBrowserJSExample/HeadlessBrowserJSExample.swift
@@ -1,0 +1,170 @@
+import Foundation
+import ActoCrawlerPlaywrightJS
+
+/// Playwright + JavaScriptKit example that mirrors `HeadlessBrowserExample`.
+@main
+struct HeadlessBrowserJSExample
+{
+    static func main()
+    {
+        JavaScriptEventLoop.installGlobalExecutor()
+
+        Task {
+            await self.run()
+        }
+    }
+
+    private static func run() async
+    {
+        let browserBox = BrowserBox()
+
+        struct Output: Sendable
+        {
+            let screenshotPath: String
+        }
+
+        let exampleDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+        let outputDir = "\(exampleDir)/output"
+
+        let crawler = await Crawler<Output, Void>.withPlaywrightJS(
+            config: CrawlerConfig(
+                maxTotalRequests: 8,
+                domainQueueTable: [
+                    ".*": .init(maxConcurrency: 5, delay: 0)
+                ]
+            ),
+            browser: { playwright in
+                let chromium = try object(from: playwright["chromium"], label: "playwright.chromium")
+                let options: JSObject = ["headless": .boolean(false)]
+                let browser = try await awaitObject(
+                    chromium.launch!(options),
+                    label: "playwright.chromium.launch"
+                )
+                browserBox.object = browser
+                return browser
+            },
+            crawl: { request, _, browser in
+                let context = try await awaitObject(browser.newContext!(), label: "browser.newContext")
+                let page = try await awaitObject(context.newPage!(), label: "context.newPage")
+
+                _ = try await awaitValue(
+                    page.goto!(request.url.absoluteString),
+                    label: "page.goto"
+                )
+
+                let screenshotPath = "\(outputDir)/example-\(request.order).png"
+                let screenshotOptions: JSObject = ["path": .string(screenshotPath)]
+                _ = try await awaitValue(
+                    page.screenshot!(screenshotOptions),
+                    label: "page.screenshot"
+                )
+
+                let linksLocator = try object(from: page.locator!("a"), label: "page.locator")
+                let linkCountValue = try await awaitValue(
+                    linksLocator.count!(),
+                    label: "locator.count"
+                )
+                guard let linkCount = linkCountValue.number else {
+                    throw ExampleError.expectedNumber("locator.count")
+                }
+
+                var nextUserRequests: [UserRequest<Void>] = []
+
+                for index in 0 ..< Int(linkCount) {
+                    let linkLocator = try object(from: linksLocator.nth!(index), label: "locator.nth")
+                    let hrefValue = try await awaitValue(
+                        linkLocator.getAttribute!("href"),
+                        label: "locator.getAttribute"
+                    )
+
+                    if hrefValue.isNull || hrefValue.isUndefined {
+                        continue
+                    }
+
+                    guard let href = hrefValue.string else {
+                        throw ExampleError.expectedString("locator.getAttribute")
+                    }
+
+                    if let nextURL = URL(string: href, relativeTo: request.url)?.absoluteURL
+                    {
+                        nextUserRequests.append(UserRequest(url: nextURL))
+                    }
+                }
+
+                nextUserRequests.shuffle()
+
+                _ = try await awaitValue(page.close!(), label: "page.close")
+                _ = try await awaitValue(context.close!(), label: "context.close")
+
+                return (nextUserRequests, Output(screenshotPath: screenshotPath))
+            }
+        )
+
+        crawler.visit(requests: [
+            UserRequest(url: URL(string: "https://en.wikipedia.org")!),
+            UserRequest(url: URL(string: "https://ja.wikipedia.org")!),
+            UserRequest(url: URL(string: "https://zh.wikipedia.org")!),
+        ])
+
+        for await event in crawler.events {
+            switch event {
+            case let .willCrawl(req):
+                print("Crawl : 🕸️ [\(req.order)] [d=\(req.depth)] \(req.url)")
+            case let .didCrawl(req, .success(output)):
+                print("Output: ✅ [\(req.order)] [d=\(req.depth)] \(req.url), screenshotPath = \(output.screenshotPath)")
+            case let .didCrawl(req, .failure(error)):
+                print("Output: ❌ [\(req.order)] [d=\(req.depth)] \(req.url), error = \(error)")
+            }
+        }
+
+        if let browser = browserBox.object {
+            _ = try? await awaitValue(browser.close!(), label: "browser.close")
+        }
+
+        print("Output Done")
+
+        if let exitProcess = JSObject.global.__actoCrawlerPlaywright.object?["exitProcess"].object {
+            _ = exitProcess.callAsFunction(0)
+        }
+    }
+}
+
+// MARK: - Private
+
+private final class BrowserBox: @unchecked Sendable
+{
+    var object: JSObject?
+}
+
+private func awaitValue(_ value: JSValue, label: String) async throws -> JSValue
+{
+    guard let object = value.object, let promise = JSPromise(object) else {
+        throw ExampleError.expectedPromise(label)
+    }
+    return try await promise.value
+}
+
+private func object(from value: JSValue, label: String) throws -> JSObject
+{
+    guard let object = value.object else {
+        throw ExampleError.expectedObject(label)
+    }
+    return object
+}
+
+private func awaitObject(_ value: JSValue, label: String) async throws -> JSObject
+{
+    let awaitedValue = try await awaitValue(value, label: label)
+    guard let object = awaitedValue.object else {
+        throw ExampleError.expectedObject(label)
+    }
+    return object
+}
+
+private enum ExampleError: Error
+{
+    case expectedPromise(String)
+    case expectedObject(String)
+    case expectedString(String)
+    case expectedNumber(String)
+}

--- a/Examples/HeadlessBrowserJSExample/main.mjs
+++ b/Examples/HeadlessBrowserJSExample/main.mjs
@@ -1,0 +1,35 @@
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as playwright from "playwright";
+
+const exampleDir = dirname(fileURLToPath(import.meta.url));
+mkdirSync(join(exampleDir, "output"), { recursive: true });
+
+globalThis.__actoCrawlerPlaywright = {
+  playwright,
+  exitProcess: (code = 0) => process.exit(code),
+};
+
+const packageDir = new URL("../../.build/plugins/PackageToJS/outputs/Package/", import.meta.url);
+
+let instantiate;
+let defaultNodeSetup;
+
+try {
+  ({ instantiate } = await import(new URL("instantiate.js", packageDir)));
+  ({ defaultNodeSetup } = await import(new URL("platforms/node.js", packageDir)));
+} catch (error) {
+  if (
+    error?.code === "ERR_MODULE_NOT_FOUND" &&
+    String(error.message).includes("@bjorn3/browser_wasi_shim")
+  ) {
+    console.error(
+      "Missing generated package dependencies. Run `npm install --prefix .build/plugins/PackageToJS/outputs/Package` first."
+    );
+  }
+  throw error;
+}
+
+const options = await defaultNodeSetup();
+await instantiate(options);

--- a/Examples/HeadlessBrowserJSExample/package-lock.json
+++ b/Examples/HeadlessBrowserJSExample/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "headless-browser-js-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "headless-browser-js-example",
+      "dependencies": {
+        "playwright": "^1.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/Examples/HeadlessBrowserJSExample/package.json
+++ b/Examples/HeadlessBrowserJSExample/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "headless-browser-js-example",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "playwright": "^1.0.0"
+  }
+}

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,5 +1,7 @@
 # Examples
 
+Repository root has a convenience `Makefile` for running the examples.
+
 ## ScraperExample
 
 Basic HTML scraper using `ActoCrawlerHTML` and [SwiftSoup](https://github.com/scinfu/SwiftSoup).
@@ -55,3 +57,44 @@ swift run HeadlessBrowserExample
 ```
 
 Screenshots will be saved to `screenshots/` in the working directory.
+
+## HeadlessBrowserJSExample
+
+Headless browser crawler using npm `playwright` via [JavaScriptKit](https://github.com/swiftwasm/JavaScriptKit).
+This example builds Swift to WebAssembly, injects Playwright from Node.js, visits real pages, and saves screenshots through the JavaScriptKit adapter.
+
+### Prerequisites
+
+- A SwiftWasm-compatible `swift` toolchain. Do not use the default Xcode toolchain for the `js` command.
+- A matching wasm SDK. The validated SDK ID for this repository is `DEVELOPMENT-SNAPSHOT-2025-09-14-a-wasm32-unknown-wasip1-threads`.
+- Node.js and npm
+
+### Setup
+
+1. Install npm dependencies:
+
+```bash
+cd Examples/HeadlessBrowserJSExample
+npm install
+```
+
+2. Install Playwright browser binaries:
+
+```bash
+npx playwright install chromium
+```
+
+### Build
+
+```bash
+swift package --disable-sandbox --swift-sdk DEVELOPMENT-SNAPSHOT-2025-09-14-a-wasm32-unknown-wasip1-threads js --product HeadlessBrowserJSExample
+npm install --prefix .build/plugins/PackageToJS/outputs/Package
+```
+
+### Run
+
+```bash
+node Examples/HeadlessBrowserJSExample/main.mjs
+```
+
+Screenshots will be saved to `Examples/HeadlessBrowserJSExample/output/`.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+SWIFT ?= swift
+SWIFT_WASM ?= $(HOME)/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2025-09-14-a.xctoolchain/usr/bin/swift
+WASM_SDK ?= DEVELOPMENT-SNAPSHOT-2025-09-14-a-wasm32-unknown-wasip1-threads
+
+.PHONY: run-scraper
+run-scraper:
+	$(SWIFT) run ScraperExample
+
+.PHONY: run-image
+run-image:
+	$(SWIFT) run ImageScraperExample
+
+.PHONY: run-paging
+run-paging:
+	$(SWIFT) run PagingScraperExample
+
+.PHONY: setup-headless-browser
+setup-headless-browser:
+	cd Examples/HeadlessBrowserExample && uv sync
+	cd Examples/HeadlessBrowserExample && uv run playwright install
+
+.PHONY: run-headless-browser
+run-headless-browser:
+	$(SWIFT) run HeadlessBrowserExample
+
+.PHONY: setup-headless-browser-js
+setup-headless-browser-js:
+	cd Examples/HeadlessBrowserJSExample && npm install
+	cd Examples/HeadlessBrowserJSExample && npx playwright install chromium
+
+.PHONY: build-headless-browser-js
+build-headless-browser-js:
+	$(SWIFT_WASM) package --disable-sandbox --swift-sdk $(WASM_SDK) js --product HeadlessBrowserJSExample
+	npm install --prefix .build/plugins/PackageToJS/outputs/Package
+
+.PHONY: run-headless-browser-js
+run-headless-browser-js: build-headless-browser-js
+	node Examples/HeadlessBrowserJSExample/main.mjs

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c33d5ba8a7be0d8004a585dd43c4dbc75f7d37f95f9593b7a811bae83ecdffb2",
+  "originHash" : "5ebe4aa5ae053467bde88ef512a92740df7849787487e4abe71ff38a944d9c6e",
   "pins" : [
     {
       "identity" : "actomaton",
@@ -7,7 +7,16 @@
       "location" : "https://github.com/inamiy/Actomaton.git",
       "state" : {
         "branch" : "main",
-        "revision" : "e648f64196d434b76452490b173748cc95dba1be"
+        "revision" : "7dda2287c9abfeddef8c5965226d59ab43754ad7"
+      }
+    },
+    {
+      "identity" : "javascriptkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftwasm/JavaScriptKit.git",
+      "state" : {
+        "revision" : "df32a66879cd5e1bbd12308d2fc248cf84fef5d3",
+        "version" : "0.50.0"
       }
     },
     {
@@ -71,6 +80,15 @@
       "state" : {
         "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,9 @@ let package = Package(
         .library(
             name: "ActoCrawlerPlaywright",
             targets: ["ActoCrawlerPlaywright"]),
+        .library(
+            name: "ActoCrawlerPlaywrightJS",
+            targets: ["ActoCrawlerPlaywrightJS"]),
         .executable(
             name: "ScraperExample",
             targets: ["ScraperExample"]),
@@ -30,11 +33,15 @@ let package = Package(
         .executable(
             name: "HeadlessBrowserExample",
             targets: ["HeadlessBrowserExample"]),
+        .executable(
+            name: "HeadlessBrowserJSExample",
+            targets: ["HeadlessBrowserJSExample"]),
     ],
     dependencies: [
         .package(url: "https://github.com/inamiy/Actomaton.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
+        .package(url: "https://github.com/swiftwasm/JavaScriptKit.git", from: "0.50.0"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.4.2"),
         .package(url: "https://github.com/pvieito/PythonKit.git", branch: "master"),
     ],
@@ -76,9 +83,24 @@ let package = Package(
                 "ActoCrawler", "PythonKitAsync"
             ]
         ),
+        .target(
+            name: "ActoCrawlerPlaywrightJS",
+            dependencies: [
+                "ActoCrawler",
+                .product(name: "JavaScriptKit", package: "JavaScriptKit"),
+                .product(name: "JavaScriptEventLoop", package: "JavaScriptKit"),
+            ]
+        ),
         .testTarget(
             name: "ActoCrawlerTests",
             dependencies: ["ActoCrawler"]),
+        .testTarget(
+            name: "ActoCrawlerPlaywrightJSTests",
+            dependencies: [
+                "ActoCrawlerPlaywrightJS",
+                .product(name: "JavaScriptEventLoopTestSupport", package: "JavaScriptKit"),
+            ]
+        ),
         .executableTarget(
             name: "ScraperExample",
             dependencies: ["ActoCrawlerHTML"],
@@ -96,6 +118,11 @@ let package = Package(
             dependencies: ["ActoCrawlerPlaywright"],
             path: "Examples/HeadlessBrowserExample",
             exclude: ["pyproject.toml", "uv.lock", "output"]),
+        .executableTarget(
+            name: "HeadlessBrowserJSExample",
+            dependencies: ["ActoCrawlerPlaywrightJS"],
+            path: "Examples/HeadlessBrowserJSExample",
+            exclude: ["main.mjs", "package.json", "package-lock.json", "node_modules", "output"]),
     ],
     swiftLanguageModes: [.v6]
 )

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 - `ActoCrawlerNetworking`: Networking helpers such as `NetworkSession`, `Response`, and `withNetworkSession`.
 - `ActoCrawlerHTML`: HTML scraping helpers such as `htmlScraper` backed by [SwiftSoup](https://github.com/scinfu/SwiftSoup).
 - `ActoCrawlerPlaywright`: Native headless-browser adapter using [playwright-python](https://playwright.dev/python/docs/intro) via [PythonKit](https://github.com/pvieito/PythonKit.git).
+- `ActoCrawlerPlaywrightJS`: WebAssembly headless-browser adapter using npm `playwright` via [JavaScriptKit](https://github.com/swiftwasm/JavaScriptKit).
+
 ## Example
 
 - [Examples](Examples)
@@ -61,6 +63,15 @@ for await event in htmlCrawler.events {
 
 print("Output Done")
 ```
+
+## Headless Browser Adapters
+
+Two Playwright integrations are available.
+
+- `ActoCrawlerPlaywright` is the native macOS path and is demonstrated by `Examples/HeadlessBrowserExample`.
+- `ActoCrawlerPlaywrightJS` is the WebAssembly path and is demonstrated by `Examples/HeadlessBrowserJSExample`.
+
+The JavaScriptKit adapter expects the surrounding JavaScript runtime to install Playwright on `globalThis.__actoCrawlerPlaywright.playwright` before the wasm module is instantiated. The example bootstrap in `Examples/HeadlessBrowserJSExample/main.mjs` does this automatically.
 
 ## Acknowledgements
 

--- a/Sources/ActoCrawlerPlaywrightJS/Crawler.withPlaywrightJS.swift
+++ b/Sources/ActoCrawlerPlaywrightJS/Crawler.withPlaywrightJS.swift
@@ -1,0 +1,59 @@
+import Foundation
+import ActoCrawler
+import JavaScriptEventLoop
+@preconcurrency import JavaScriptKit
+
+extension Crawler
+{
+    /// Helper initializer that adds Playwright from the JavaScript runtime as ActoCrawler's dependency.
+    ///
+    /// The surrounding JavaScript environment must install Playwright on
+    /// `globalThis.__actoCrawlerPlaywright.playwright` before instantiating the wasm module.
+    ///
+    /// - Parameters:
+    ///   - browser:
+    ///     Creates a reusable object from Playwright, usually a `Browser`.
+    ///     If `nil`, Chromium with non-headless mode will launch.
+    ///
+    ///   - crawl:
+    ///     Crawling function that receives Playwright and Browser as `JSObject`s for JavaScript inter-op.
+    public static func withPlaywrightJS(
+        config: CrawlerConfig,
+        browser: (@Sendable (_ playwright: JSObject) async throws -> JSObject)? = nil,
+        crawl: @escaping @Sendable (
+            Request<URLInfo>,
+            _ playwright: JSObject,
+            _ browser: JSObject
+        ) async throws -> ([UserRequest<URLInfo>], Output)
+    ) async -> Crawler<Output, URLInfo>
+    {
+        JavaScriptEventLoop.installGlobalExecutor()
+
+        let playwrightActor = PlaywrightJSActor(
+            prepare: browser ?? { playwright in
+                let chromium = try jsObjectProperty(
+                    playwright,
+                    "chromium",
+                    label: "globalThis.__actoCrawlerPlaywright.playwright.chromium"
+                )
+                let options: JSObject = ["headless": .boolean(false)]
+                return try await callJSMethodObject(
+                    chromium,
+                    method: "launch",
+                    arguments: [options],
+                    label: "playwright.chromium.launch"
+                )
+            }
+        )
+
+        return Crawler<Output, URLInfo>(
+            config: config,
+            dependency: playwrightActor,
+            crawl: { request, playwrightActor in
+                try await playwrightActor.runCrawl {
+                    try await crawl(request, $0, $1)
+                }
+            }
+        )
+    }
+}

--- a/Sources/ActoCrawlerPlaywrightJS/Internal/JSInterop.swift
+++ b/Sources/ActoCrawlerPlaywrightJS/Internal/JSInterop.swift
@@ -1,0 +1,147 @@
+import Foundation
+import JavaScriptEventLoop
+@preconcurrency import JavaScriptKit
+
+internal enum PlaywrightJSBootstrapError: Error, Sendable
+{
+    case missingGlobal(String)
+    case expectedObject(String)
+    case expectedFunction(String)
+    case expectedPromise(String)
+    case expectedString(String)
+    case expectedArrayLike(String)
+}
+
+extension PlaywrightJSBootstrapError: LocalizedError
+{
+    var errorDescription: String?
+    {
+        switch self {
+        case let .missingGlobal(label):
+            return "Missing JavaScript global: \(label)"
+        case let .expectedObject(label):
+            return "Expected JavaScript object: \(label)"
+        case let .expectedFunction(label):
+            return "Expected JavaScript function: \(label)"
+        case let .expectedPromise(label):
+            return "Expected JavaScript Promise: \(label)"
+        case let .expectedString(label):
+            return "Expected JavaScript string: \(label)"
+        case let .expectedArrayLike(label):
+            return "Expected JavaScript array-like object: \(label)"
+        }
+    }
+}
+
+internal func resolvePlaywrightModule() async throws -> JSObject
+{
+    let container = try jsObjectProperty(
+        JSObject.global,
+        "__actoCrawlerPlaywright",
+        label: "globalThis.__actoCrawlerPlaywright"
+    )
+    return try jsObjectProperty(
+        container,
+        "playwright",
+        label: "globalThis.__actoCrawlerPlaywright.playwright"
+    )
+}
+
+internal func awaitJSValue(_ value: JSValue, label: String) async throws -> JSValue
+{
+    guard let object = value.object, let promise = JSPromise(object) else {
+        throw PlaywrightJSBootstrapError.expectedPromise(label)
+    }
+    return try await promise.value
+}
+
+internal func awaitJSObject(_ value: JSValue, label: String) async throws -> JSObject
+{
+    let awaitedValue = try await awaitJSValue(value, label: label)
+    guard let object = awaitedValue.object else {
+        throw PlaywrightJSBootstrapError.expectedObject(label)
+    }
+    return object
+}
+
+internal func makeJSObject(_ configure: (JSObject) -> Void) -> JSObject
+{
+    let object = JSObject()
+    configure(object)
+    return object
+}
+
+internal func jsObjectProperty(_ receiver: JSObject, _ property: String, label: String) throws -> JSObject
+{
+    let value = receiver[property]
+    if value.isUndefined {
+        throw PlaywrightJSBootstrapError.missingGlobal(label)
+    }
+    guard let object = value.object else {
+        throw PlaywrightJSBootstrapError.expectedObject(label)
+    }
+    return object
+}
+
+internal func jsFunctionProperty(_ receiver: JSObject, _ property: String, label: String) throws -> JSObject
+{
+    let value = receiver[property]
+    if value.isUndefined {
+        throw PlaywrightJSBootstrapError.missingGlobal(label)
+    }
+    guard let function = value.object else {
+        throw PlaywrightJSBootstrapError.expectedFunction(label)
+    }
+    return function
+}
+
+internal func callJSMethod(
+    _ receiver: JSObject,
+    method: String,
+    arguments: [ConvertibleToJSValue] = [],
+    label: String
+) throws -> JSValue
+{
+    let function = try jsFunctionProperty(receiver, method, label: label)
+    return function.callAsFunction(this: receiver, arguments: arguments)
+}
+
+internal func callJSMethodValue(
+    _ receiver: JSObject,
+    method: String,
+    arguments: [ConvertibleToJSValue] = [],
+    label: String
+) async throws -> JSValue
+{
+    try await awaitJSValue(
+        try callJSMethod(receiver, method: method, arguments: arguments, label: label),
+        label: label
+    )
+}
+
+internal func callJSMethodObject(
+    _ receiver: JSObject,
+    method: String,
+    arguments: [ConvertibleToJSValue] = [],
+    label: String
+) async throws -> JSObject
+{
+    try await awaitJSObject(
+        try callJSMethod(receiver, method: method, arguments: arguments, label: label),
+        label: label
+    )
+}
+
+internal func jsStringArray(from object: JSObject, label: String) throws -> [String]
+{
+    guard let length = object["length"].number else {
+        throw PlaywrightJSBootstrapError.expectedArrayLike("\(label).length")
+    }
+
+    return try (0 ..< Int(length)).map { index in
+        guard let string = object[index].string else {
+            throw PlaywrightJSBootstrapError.expectedString("\(label)[\(index)]")
+        }
+        return string
+    }
+}

--- a/Sources/ActoCrawlerPlaywrightJS/PlaywrightJSActor.swift
+++ b/Sources/ActoCrawlerPlaywrightJS/PlaywrightJSActor.swift
@@ -1,0 +1,57 @@
+import JavaScriptEventLoop
+@preconcurrency import JavaScriptKit
+
+/// Playwright actor wrapper that lazily resolves the injected JavaScript module.
+internal actor PlaywrightJSActor
+{
+    private struct State
+    {
+        let playwright: JSObject
+        let preparedObject: JSObject
+    }
+
+    private let resolvePlaywright: @Sendable () async throws -> JSObject
+    private let prepare: @Sendable (_ playwright: JSObject) async throws -> JSObject
+    private var state: State?
+
+    internal init(
+        resolvePlaywright: @escaping @Sendable () async throws -> JSObject = resolvePlaywrightModule,
+        prepare: @escaping @Sendable (_ playwright: JSObject) async throws -> JSObject
+    )
+    {
+        self.resolvePlaywright = resolvePlaywright
+        self.prepare = prepare
+    }
+
+    internal func runCrawl<Res: Sendable>(
+        _ crawl: @Sendable (
+            _ playwright: JSObject,
+            _ preparedObject: JSObject
+        ) async throws -> Res
+    ) async throws -> Res
+    {
+        let state = try await self.bootstrap()
+        return try await crawl(state.playwright, state.preparedObject)
+    }
+
+    private func bootstrap() async throws -> State
+    {
+        if let state = self.state {
+            return state
+        }
+
+        JavaScriptEventLoop.installGlobalExecutor()
+
+        let playwright = try await self.resolvePlaywright()
+        let preparedObject = try await self.prepare(playwright)
+
+        let state = State(playwright: playwright, preparedObject: preparedObject)
+        self.state = state
+        return state
+    }
+
+    internal nonisolated var unownedExecutor: UnownedSerialExecutor
+    {
+        JavaScriptEventLoop.shared.asUnownedSerialExecutor()
+    }
+}

--- a/Sources/ActoCrawlerPlaywrightJS/_exported.swift
+++ b/Sources/ActoCrawlerPlaywrightJS/_exported.swift
@@ -1,0 +1,3 @@
+@_exported import ActoCrawler
+@_exported import JavaScriptEventLoop
+@_exported import JavaScriptKit

--- a/Tests/ActoCrawlerPlaywrightJSTests/ActoCrawlerPlaywrightJSTests.swift
+++ b/Tests/ActoCrawlerPlaywrightJSTests/ActoCrawlerPlaywrightJSTests.swift
@@ -1,0 +1,232 @@
+import XCTest
+
+#if arch(wasm32)
+@testable import ActoCrawlerPlaywrightJS
+import JavaScriptEventLoop
+@preconcurrency import JavaScriptKit
+
+final class ActoCrawlerPlaywrightJSTests: XCTestCase
+{
+    override class func setUp()
+    {
+        JavaScriptEventLoop.installGlobalExecutor()
+    }
+
+    func testBrowserIsReusedAcrossCrawls() async throws
+    {
+        let fixture = FakePlaywrightFixture(
+            linksByURL: [
+                "https://example.com": [
+                    "https://example.com/child-1",
+                    "https://example.com/child-2",
+                ],
+                "https://example.com/child-1": [],
+                "https://example.com/child-2": [],
+            ]
+        )
+        fixture.install()
+        defer { fixture.uninstall() }
+
+        let crawler = await Crawler<String, Void>.withPlaywrightJS(
+            config: CrawlerConfig(
+                maxTotalRequests: 3,
+                domainQueueTable: [
+                    ".*": .init(maxConcurrency: 3, delay: 0)
+                ]
+            ),
+            crawl: { request, _, browser in
+                let context = try await callJSMethodObject(
+                    browser,
+                    method: "newContext",
+                    label: "browser.newContext"
+                )
+                let page = try await callJSMethodObject(
+                    context,
+                    method: "newPage",
+                    label: "context.newPage"
+                )
+
+                _ = try await callJSMethodValue(
+                    page,
+                    method: "goto",
+                    arguments: [request.url.absoluteString],
+                    label: "page.goto"
+                )
+
+                let screenshotPath = "/tmp/example-\(request.order).png"
+                let screenshotOptions: JSObject = ["path": .string(screenshotPath)]
+                _ = try await callJSMethodValue(
+                    page,
+                    method: "screenshot",
+                    arguments: [screenshotOptions],
+                    label: "page.screenshot"
+                )
+
+                let linkObjects = try await callJSMethodObject(
+                    page,
+                    method: "evaluate",
+                    arguments: ["() => Array.from(document.links).map(item => item.href)"],
+                    label: "page.evaluate"
+                )
+                let nextRequests = try jsStringArray(from: linkObjects, label: "page.evaluate")
+                    .compactMap { URL(string: $0).map(UserRequest.init(url:)) }
+
+                _ = try await callJSMethodValue(page, method: "close", label: "page.close")
+                _ = try await callJSMethodValue(context, method: "close", label: "context.close")
+
+                return (nextRequests, screenshotPath)
+            }
+        )
+
+        crawler.visit(url: URL(string: "https://example.com")!)
+
+        var outputs: [String] = []
+        for await event in crawler.events {
+            if case let .didCrawl(_, .success(output)) = event {
+                outputs.append(output)
+            }
+        }
+
+        XCTAssertEqual(outputs.count, 3)
+        XCTAssertEqual(fixture.launchCallCount, 1)
+        XCTAssertEqual(fixture.newContextCallCount, 3)
+        XCTAssertEqual(fixture.gotoURLs, [
+            "https://example.com",
+            "https://example.com/child-1",
+            "https://example.com/child-2",
+        ])
+        XCTAssertEqual(fixture.screenshotPaths, [
+            "/tmp/example-0.png",
+            "/tmp/example-1.png",
+            "/tmp/example-2.png",
+        ])
+    }
+
+    func testMissingBootstrapBecomesCrawlFailure() async throws
+    {
+        JSObject.global["__actoCrawlerPlaywright"] = .undefined
+
+        let crawler = await Crawler<Int, Void>.withPlaywrightJS(
+            config: CrawlerConfig(
+                maxTotalRequests: 1,
+                domainQueueTable: [
+                    ".*": .init(maxConcurrency: 1, delay: 0)
+                ]
+            ),
+            crawl: { _, _, _ in
+                XCTFail("crawl should not be called when bootstrap is missing")
+                return ([], 0)
+            }
+        )
+
+        crawler.visit(url: URL(string: "https://example.com")!)
+
+        var receivedError: CrawlError?
+        for await event in crawler.events {
+            if case let .didCrawl(_, .failure(error)) = event {
+                receivedError = error
+            }
+        }
+
+        guard case let .crawlFailed(underlyingError)? = receivedError else {
+            return XCTFail("Expected crawlFailed error, got \(String(describing: receivedError))")
+        }
+        guard case let .missingGlobal(label) = underlyingError as? PlaywrightJSBootstrapError else {
+            return XCTFail("Expected missingGlobal error, got \(underlyingError)")
+        }
+        XCTAssertEqual(label, "globalThis.__actoCrawlerPlaywright")
+    }
+}
+
+private final class FakePlaywrightFixture
+{
+    private var retainedClosures: [JSClosure] = []
+
+    private let browser = JSObject()
+    private let context = JSObject()
+    private let page = JSObject()
+
+    let linksByURL: [String: [String]]
+    var launchCallCount = 0
+    var newContextCallCount = 0
+    var gotoURLs: [String] = []
+    var screenshotPaths: [String] = []
+
+    init(linksByURL: [String: [String]])
+    {
+        self.linksByURL = linksByURL
+    }
+
+    func install()
+    {
+        let container = JSObject()
+        let playwright = JSObject()
+        let chromium = JSObject()
+
+        chromium["launch"] = .object(self.retain { _ in
+            self.launchCallCount += 1
+            return JSPromise.resolve(self.browser).jsValue()
+        })
+
+        self.browser["newContext"] = .object(self.retain { _ in
+            self.newContextCallCount += 1
+            return JSPromise.resolve(self.context).jsValue()
+        })
+
+        self.context["newPage"] = .object(self.retain { _ in
+            JSPromise.resolve(self.page).jsValue()
+        })
+
+        self.context["close"] = .object(self.retain { _ in
+            JSPromise.resolve(JSValue.undefined).jsValue()
+        })
+
+        self.page["goto"] = .object(self.retain { args in
+            self.gotoURLs.append(args.first?.string ?? "")
+            return JSPromise.resolve(JSValue.undefined).jsValue()
+        })
+
+        self.page["screenshot"] = .object(self.retain { args in
+            let path = args.first?.object?["path"].string ?? ""
+            self.screenshotPaths.append(path)
+            return JSPromise.resolve(JSValue.undefined).jsValue()
+        })
+
+        self.page["evaluate"] = .object(self.retain { _ in
+            let currentURL = self.gotoURLs.last ?? ""
+            let array = self.makeJSArray(self.linksByURL[currentURL] ?? [])
+            return JSPromise.resolve(array).jsValue()
+        })
+
+        self.page["close"] = .object(self.retain { _ in
+            JSPromise.resolve(JSValue.undefined).jsValue()
+        })
+
+        playwright["chromium"] = .object(chromium)
+        container["playwright"] = .object(playwright)
+        JSObject.global["__actoCrawlerPlaywright"] = .object(container)
+    }
+
+    func uninstall()
+    {
+        JSObject.global["__actoCrawlerPlaywright"] = .undefined
+        self.retainedClosures.removeAll()
+    }
+
+    private func retain(_ body: @escaping ([JSValue]) -> JSValue) -> JSClosure
+    {
+        let closure = JSClosure(body)
+        self.retainedClosures.append(closure)
+        return closure
+    }
+
+    private func makeJSArray(_ strings: [String]) -> JSObject
+    {
+        let array = JSObject.global.Array.object!.new()
+        for (index, string) in strings.enumerated() {
+            array[index] = .string(string)
+        }
+        return array
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add `ActoCrawlerPlaywrightJS` module — JavaScript/Wasm-based Playwright integration via JavaScriptKit, as an alternative to the Python-based `ActoCrawlerPlaywright`
- `PlaywrightJSActor` runs on `JavaScriptEventLoop` executor for safe JS interop from Swift Concurrency
- `JSInterop` helpers for bridging Swift ↔ JavaScript objects and promises
- `HeadlessBrowserJSExample` compiled to Wasm via SwiftPM PackageToJS plugin, driven by `main.mjs` + Node.js
- `Makefile` with setup / build / run targets for all examples
- Tests covering JS interop helpers and crawler integration

## Testing
- `make setup-headless-browser-js && make run-headless-browser-js`
- `swift test --filter ActoCrawlerPlaywrightJSTests` (unit tests for JS interop helpers)
