### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,9 @@ on:
   pull_request:
 
 jobs:
-  swift-build-examples:
-    name: Swift build examples
+  # Builds all targets including example executables (swift-test only covers library/test targets).
+  swift-build:
+    name: Swift build
     runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
@@ -33,7 +34,7 @@ jobs:
   required:
     name: Required
     needs:
-      - swift-build-examples
+      - swift-build
       - swift-test
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
+# https://github.com/actions/runner-images/tree/main/images/macos
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - ci/**
+  pull_request:
+
+jobs:
+  swift-test:
+    name: Swift test
+    runs-on: macos-26
+    steps:
+    - uses: actions/checkout@v4
+    - name: Select Xcode 26.4
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app
+    - name: Test
+      run: make swift-test
+
+  required:
+    name: Required
+    needs:
+      - swift-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          ! echo "$NEEDS" | jq -e 'to_entries[] | { job: .key, result: .value.result } | select((.result == "success" or .result == "skipped") | not)'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ on:
   pull_request:
 
 jobs:
-  swift-build:
-    name: Swift build
+  swift-build-examples:
+    name: Swift build examples
     runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
   required:
     name: Required
     needs:
-      - swift-build
+      - swift-build-examples
       - swift-test
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,16 @@ on:
   pull_request:
 
 jobs:
+  swift-build:
+    name: Swift build
+    runs-on: macos-26
+    steps:
+    - uses: actions/checkout@v4
+    - name: Select Xcode 26.4
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app
+    - name: Build
+      run: make swift-build
+
   swift-test:
     name: Swift test
     runs-on: macos-26
@@ -23,6 +33,7 @@ jobs:
   required:
     name: Required
     needs:
+      - swift-build
       - swift-test
     if: always()
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,22 @@ SWIFT ?= swift
 SWIFT_WASM ?= $(HOME)/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2025-09-14-a.xctoolchain/usr/bin/swift
 WASM_SDK ?= DEVELOPMENT-SNAPSHOT-2025-09-14-a-wasm32-unknown-wasip1-threads
 
+#--------------------------------------------------
+# Build & Test
+#--------------------------------------------------
+
+.PHONY: swift-build
+swift-build:
+	$(SWIFT) build
+
+.PHONY: swift-test
+swift-test:
+	$(SWIFT) test
+
+#--------------------------------------------------
+# Examples
+#--------------------------------------------------
+
 .PHONY: run-scraper
 run-scraper:
 	$(SWIFT) run ScraperExample

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version: 6.2
 
+import Foundation
 import PackageDescription
 
 let package = Package(
@@ -94,13 +95,6 @@ let package = Package(
         .testTarget(
             name: "ActoCrawlerTests",
             dependencies: ["ActoCrawler"]),
-        .testTarget(
-            name: "ActoCrawlerPlaywrightJSTests",
-            dependencies: [
-                "ActoCrawlerPlaywrightJS",
-                .product(name: "JavaScriptEventLoopTestSupport", package: "JavaScriptKit"),
-            ]
-        ),
         .executableTarget(
             name: "ScraperExample",
             dependencies: ["ActoCrawlerHTML"],
@@ -126,3 +120,17 @@ let package = Package(
     ],
     swiftLanguageModes: [.v6]
 )
+
+// MARK: - Wasm-only test target (JavaScriptKit crashes at load time on native platforms)
+
+if ProcessInfo.processInfo.environment["WASM"] != nil {
+    package.targets.append(
+        .testTarget(
+            name: "ActoCrawlerPlaywrightJSTests",
+            dependencies: [
+                "ActoCrawlerPlaywrightJS",
+                .product(name: "JavaScriptEventLoopTestSupport", package: "JavaScriptKit"),
+            ]
+        )
+    )
+}


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow (`.github/workflows/main.yml`) with `swift test` on macOS 26 / Xcode 26.4
- Add `swift-build` and `swift-test` Makefile targets for CI and local use
- Include `required` aggregator job for branch protection

## Test plan

- [x] Verify CI runs on push to `main` and on PRs
- [x] Confirm `make swift-test` passes on macOS 26 runner
- [x] Confirm `required` job gates merge correctly
